### PR TITLE
Fixed error when receiving the API as an argument

### DIFF
--- a/shodan_pharmer.py
+++ b/shodan_pharmer.py
@@ -57,7 +57,7 @@ def parse_args():
 
 def shodan_search(search, apikey):
     if apikey:
-        API_KEY = args.apikey
+        API_KEY = apikey
     else:
         API_KEY = 'ENTER YOUR API KEY HERE AND KEEP THE QUOTES'
     api = WebAPI(API_KEY)


### PR DESCRIPTION
When being passed the API key as an argument at the command line, the script errors out:
NameError: global name 'args' is not defined

Simple fix to get it working again.
