### PR TITLE
Fix dead URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,5 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ***
-* [danmcinerney.org](danmcinerney.org)
+* [danmcinerney.org](http://danmcinerney.org)
 * [![Flattr this](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=DanMcInerney&url=https://github.com/DanMcInerney/device-pharmer&title=device-pharmer&language=&tags=github&category=software) 


### PR DESCRIPTION
Clicking the link to your website in the README.md led to a dead URL
previously:
https://github.com/DanMcInerney/device-pharmer/blob/master/danmcinerney.org
This is now fixed.